### PR TITLE
Fix width of course outline 

### DIFF
--- a/coursebuilder/views/course.html
+++ b/coursebuilder/views/course.html
@@ -32,7 +32,7 @@
       <div class="course-links">
         <button class="btn">
           <a href="/#!explorer">
-            <i class="material-icons">library_books</i> 
+            <i class="material-icons">library_books</i>
             COURSES
           </a>
         </button>
@@ -84,21 +84,18 @@
                 {{ item }}
               {% endfor %}
             {% endif %}
-
           </div>
         <div class="course-card col l7 xl8 m12">
           <div class="card">
-
             <div class="gcb-cols">
               {% include 'summary.html' %}
-
               {% if transient_student %}
                 {% include 'registration_module.html' %}
               {% endif %}
             </div>
           </div>
         </div>
-        </div>
       </div>
     </div>
+  </div>
 {% endblock %}

--- a/coursebuilder/views/course.html
+++ b/coursebuilder/views/course.html
@@ -55,8 +55,6 @@
 
     <div class="course-content">
       <div class="row">
-
-
         <div class="course-accordion col l5 xl4 m12">
 
             {% if course_outline %}
@@ -88,9 +86,6 @@
             {% endif %}
 
           </div>
-
-        </div>
-
         <div class="course-card col l7 xl8 m12">
           <div class="card">
 
@@ -101,8 +96,8 @@
                 {% include 'registration_module.html' %}
               {% endif %}
             </div>
-
           </div>
+        </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
#### What does this PR do?
- Ensure course outline and course accordion are in the same grid.

#### Description of task completed?
- Move the `course-content card` inside the grid system i.e `row container`.

#### Screenshots 
- Before
![before digital solutions course](https://user-images.githubusercontent.com/28448041/32361424-79dbab5e-c060-11e7-8d22-0fe895fbfc86.png)

- After
![digital solutions course after](https://user-images.githubusercontent.com/28448041/32361428-8917e1fa-c060-11e7-8200-88249ca1504e.png)


#### Link to test
- https://cfafrica-mooc-dev.appspot.com/digital-solutions/course
